### PR TITLE
Write all deals from special feeds into a file

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -3,7 +3,7 @@ if (process.env.NODE_ENV !== 'production') {
   require('dotenv').load();
 }
 
-var walmart = require('../index.js')(process.env.WALMART_API_KEY, {protocol: 'http'});
+var walmart = require('../index_for_pagination.js')(process.env.WALMART_API_KEY, {protocol: 'http'});
 
 function writeSubCategoryIdsToFile(){
   /*
@@ -46,6 +46,7 @@ function writeCategoryIdsToFile(){
   walmart.taxonomy().then(function(data){
     data.categories.forEach(function(category){
       var cat_info = category.name + ',' + category.id+'\n';
+
       fs.appendFileSync('category_info.txt', cat_info);
     })
   });
@@ -75,12 +76,38 @@ function extractProductInfo(product){
 }
 
 
+function getRecursiveResponse(response){
+  var results_array = [];
+  if (response != undefined && response.hasOwnProperty('items')){
+    response.items.forEach(function(item){
+      // uses upc for identification
+      if (item.hasOwnProperty('upc')){
+        results_array.push(extractProductInfo(item));
+      }
+    })
+    if (response.nextPage) {
+      var new_page_response = walmart.getNewPage(response.nextPage);
+      new_page_response.then(function(resp){
+        results_array = results_array.concat(results_array, getRecursiveResponse(resp));
+      })      
+    }
+    results_array.forEach(function(item){
+      fs.appendFile('special_feeds_items.txt', item, (err) => {
+        if (err) throw err;
+      });
+    })
+    
+    return;
+  }
+}
+
+
 /*
 function that serially calls Promise functions and waits for each of them to be resolved
 Reference: https://hackernoon.com/functional-javascript-resolving-promises-sequentially-7aac18c4431e
 */
-const promiseSerial = category_clearance_array =>
-category_clearance_array.reduce((promise, func) =>
+const promiseSerial = cat_array =>
+cat_array.reduce((promise, func) =>
 promise.then(result => func().then(Array.prototype.concat.bind(result))),
 Promise.resolve([]))
 
@@ -95,30 +122,28 @@ function getSpecialFeedsItems(){
     So, omitting them from the category_array we are getting feeds info for.
     Run writeCategoryIdsToFile() if interested in the names of the categories
   */
+
   var invalid_clearance_cat_id_array = ["3920", "976759", "1094765", "6197502", "6197502", "4096", "4104", 
-                                "7796869", "1005862", "5426", "6163033"];
+                                "7796869", "1005862", "5426", "6163033", "5440", "2636"];
   var invalid_preorder_cat_id_array = ["1094765", "6197502", "1005862"];
-  var invalid_specialbuy_cat_id_array = ["4104"];
-  //rollback doesn't work at the moment
-  var special_feeds_array = ["clearance", "specialbuy", "bestsellers", "preorder"]; 
+  var invalid_specialbuy_cat_id_array = ["4104"];  
+  var special_feeds_array = ["clearance", "specialbuy", "bestsellers", "preorder"];
   walmart.taxonomy().then(function(result) { 
     var valid_cat_id_array = []
     result.categories.forEach(function(category){
       special_feeds_array.forEach(function(feed){
-        //if feed is clearance, of the categories returned, use only the valid ones
+        //return only valid categories for feeds. Valid categories found through testing
         if (feed == "clearance") {
           if (!(invalid_clearance_cat_id_array.includes(category.id))) {
             valid_cat_id_array.push(feed+","+category.id);
           }
         }
         else if (feed == "preorder") {
-          //if feed is preorder, of the categories returned, use only the valid ones
           if (!(invalid_preorder_cat_id_array.includes(category.id))) {
             valid_cat_id_array.push(feed+","+category.id);
           }
         }
         else if (feed == "specialbuy") {
-          //if feed is specialbuy, of the categories returned, use only the valid ones
           if (!(invalid_specialbuy_cat_id_array.includes(category.id))) {
             valid_cat_id_array.push(feed+","+category.id);
           }
@@ -128,31 +153,74 @@ function getSpecialFeedsItems(){
         }
       })               
     })
-
+  
     // map clearance call over valid_cat_id_array
     var category_feed_array = valid_cat_id_array.map(feed_and_cat_id => () => walmart.getSpecifiedFeed(feed_and_cat_id));
     
     // execute Promises serially
     promiseSerial(category_feed_array)
-      .then(function(output){
-        output.forEach(function(results){
-          if (results.items.length > 0) {
-            results.items.forEach(function(item){
-              /*because we want to compare the features of this item to another marketplace 
-                using some identifier like UPC, it doesn't make sense to retrieve items that don't
-                have a UPC. We can review this decision if we find other identifiers
-              */
-              if (item.hasOwnProperty('upc')){
-                fs.appendFileSync('special_feeds_items.txt', extractProductInfo(item));
-              }
-            })
-          }
+      .then(function(results){
+        results.forEach(function(item){
+          //uses upc for identification
+          if (item.hasOwnProperty('upc')){
+            //writing file blocks occasionally, so setting time out to 30 milliseconds for each write
+            setTimeout(function(){ fs.appendFileSync('special_feeds_items.txt', extractProductInfo(item)) }, 30);;
+          }        
         })
       })
       .catch(console.error.bind(console))
   });
 }
 
+
+function getSingleListOfPaginatedItems(feed_and_cat_id){
+  
+  //Writes all the feed deals in string representing a feed and category id to a file. 
+  
+  //prepare to use feed and cat_id by splitting them
+  feed = feed_and_cat_id.split(',')[0]
+  cat_id = feed_and_cat_id.split(',')[1]
+  
+  return new Promise(
+    function (resolve, reject) {
+      walmart.paginateByCategory(parseInt(cat_id), feed, function(response) {
+        var results_array = getRecursiveResponse(response);
+        resolve();
+      });
+    }
+  );
+}
+
+
+function getPaginatedSpecialFeeds(){
+  /*
+    Goes through all valid feed/category combinations and returns Promises of getSingleListOfPaginatedItems
+  */
+  
+  special_feeds_array = [ "specialbuy", "preorder", "clearance" ];
+  //get categories available and retrieve deal information for each one
+  walmart.taxonomy().then(function(result) {
+    var valid_cat_id_array = [];
+    result.categories.forEach(function(category){
+      special_feeds_array.forEach(function(feed){
+        /*
+          go through each feed and prepare string combination of feed and cat_id
+          to retrieve information for.
+        */
+          valid_cat_id_array.push(feed+","+category.id); 
+      })
+    });
+
+    // map clearance call over valid_cat_id_array
+    var category_special_feeds_array = valid_cat_id_array.map(feed_and_cat_id => () => getSingleListOfPaginatedItems(feed_and_cat_id));
+    
+    // execute Promises serially
+    promiseSerial(category_special_feeds_array)
+  })
+}
+
+
+
+
 getSpecialFeedsItems();
-
-
+//getPaginatedSpecialFeeds();

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -3,7 +3,7 @@ if (process.env.NODE_ENV !== 'production') {
   require('dotenv').load();
 }
 
-var walmart = require('../index.js')(process.env.WALMART_API_KEY, {protocol: 'http'});
+let walmart = require('../index.js')(process.env.WALMART_API_KEY, {protocol: 'http'});
 
 function writeSubCategoryIdsToFile(){
   /*
@@ -20,18 +20,18 @@ function writeSubCategoryIdsToFile(){
         category.children.forEach(function(child){
           if (child.hasOwnProperty('children')){
             child.children.forEach(function(grand_child){
-              var cat_info = grand_child.path + ',' + grand_child.id+'\n';
+              let cat_info = grand_child.path + ',' + grand_child.id+'\n';
               fs.appendFileSync('subcategory_info.txt', cat_info);
             })
           }
           else {
-            var cat_info = child.path + ',' + child.id+'\n';
+            let cat_info = child.path + ',' + child.id+'\n';
             fs.appendFileSync('subcategory_info.txt', cat_info);
           }
         })
       }
       else {
-        var cat_info = category.name + ' ' + category.id+'\n';
+        let cat_info = category.name + ' ' + category.id+'\n';
         fs.appendFileSync('subcategory_info.txt', cat_info);
       }
     })
@@ -45,7 +45,7 @@ function writeCategoryIdsToFile(){
   */
   walmart.taxonomy().then(function(data){
     data.categories.forEach(function(category){
-      var cat_info = category.name + ',' + category.id+'\n';
+      let cat_info = category.name + ',' + category.id+'\n';
 
       fs.appendFileSync('category_info.txt', cat_info);
     })
@@ -59,25 +59,24 @@ function writeCategoryIdsOnlyToFile(){
   */
   walmart.taxonomy().then(function(data){
     data.categories.forEach(function(category){
-      var cat_info = category.id+'\n';
+      let cat_info = category.id+'\n';
       fs.appendFileSync('category_ids.txt', cat_info);
     })
   });
 }
 
 function extractProductInfo(product){
-  var twoThreeDayShippingRate = Object.is(product.twoThreeDayShippingRate, undefined) ? '-1.00' : product.twoThreeDayShippingRate; 
-  var msrp = Object.is(product.msrp, undefined) ? '-1.00' : product.msrp;
-  var product_info=product.itemId+','+product.upc+','+product.name+','+product.brandName+','
-    +msrp+','+product.salePrice+','+product.standardShipRate+','
-    +twoThreeDayShippingRate+','+product.availableOnline+','+product.categoryNode
-    +','+product.stock+','+product.freeShippingOver50Dollars+'\n';
+  let twoThreeDayShippingRate = Object.is(product.twoThreeDayShippingRate, undefined) ? '-1.00' : product.twoThreeDayShippingRate; 
+  let msrp = Object.is(product.msrp, undefined) ? '-1.00' : product.msrp;
+  let product_info=`${product.itemId},${product.upc},${product.name},${product.brandName},`
+  product_info=product_info+`${msrp},${product.salePrice},${product.standardShipRate},${twoThreeDayShippingRate},`
+  product_info=product_info+`${product.availableOnline},${product.categoryNode},${product.stock},${product.stock},`
+  product_info=product_info+`${product.freeShippingOver50Dollars}\n`
   return product_info;
 }
 
-
-function getRecursiveResponse(response){
-  var results_array = [];
+function getRecursiveResponse(response, idx){
+  let results_array = [];
   if (response != undefined && response.hasOwnProperty('items')){
     response.items.forEach(function(item){
       // uses upc for identification
@@ -86,11 +85,11 @@ function getRecursiveResponse(response){
       }
     })
     if (response.nextPage) {
-      var new_page_response = walmart.getNewPage(response.nextPage);
-      new_page_response.then(function(resp){
-        results_array = results_array.concat(getRecursiveResponse(resp));
+      walmart.getNewPage(response.nextPage, idx).then(function(resp){
+        results_array = results_array.concat(getRecursiveResponse(resp, (idx+1)));
       })      
     }
+
     results_array.forEach(function(item){
       fs.appendFile('special_feeds_items.txt', item, (err) => {
         if (err) throw err;
@@ -101,37 +100,22 @@ function getRecursiveResponse(response){
   }
 }
 
-
-/*
-function that serially calls Promise functions and waits for each of them to be resolved
-Reference: https://hackernoon.com/functional-javascript-resolving-promises-sequentially-7aac18c4431e
-*/
-const paginatedPromiseSerial = cat_array =>
-  cat_array.reduce((promise, func) =>
-  promise.then(result => func().then(Array.prototype.concat.bind(result))), Promise.resolve([]))
-
-
-
-
-
-
-
 function getSpecialFeedsItems(){
   /*
     Gets special feeds deals on items available in all categories.
   */
   
-  var special_feeds_array = ["clearance", "specialbuy", "bestsellers", "preorder"];
+  let special_feeds_array = ["clearance", "specialbuy", "bestsellers", "preorder"];
   
   walmart.taxonomy().then(function(result) { 
     //counters for the categories that we got deals for
-    var promises_fulfilled = 0
-    var upc_items_count = 0;
-    var prom_with_items = 0;
-    var total_items_count = 0;
+    let promises_fulfilled = 0
+    let upc_items_count = 0;
+    let prom_with_items = 0;
+    let total_items_count = 0;
     
-    var category_id_array = []; //holds all feeds/category info
-    var category_feed_promises_array = []; //holds promises for each feed/category request
+    let category_id_array = []; //holds all feeds/category info
+    let category_feed_promises_array = []; //holds promises for each feed/category request
 
     //prepare all feed/id combination to be requested
     result.categories.forEach(function(category){
@@ -152,7 +136,7 @@ function getSpecialFeedsItems(){
     Promise.all(category_feed_promises_array.map(function(promise) {
       return promise.reflect();
     })).then(function(inspections) {
-      var results_array = [];  //saves results of all fulfilled deals    
+      let results_array = [];  //saves results of all fulfilled deals    
       inspections.forEach(function(inspection) {       
         if (inspection.isFulfilled()) {
           promises_fulfilled = promises_fulfilled +1;
@@ -171,7 +155,7 @@ function getSpecialFeedsItems(){
       return results_array;
     }).then(function(results){
         //write to file
-        var special_feeds_file = fs.createWriteStream('special_feeds_items.txt');
+        let special_feeds_file = fs.createWriteStream('special_feeds_items.txt');
         special_feeds_file.on('error', function(err) { console.log(err)/* error handling */ });
         results.forEach(function(upc_item) { special_feeds_file.write(extractProductInfo(upc_item)); });
         special_feeds_file.end();
@@ -186,53 +170,44 @@ function getSpecialFeedsItems(){
   });
 }
 
-function getSingleListOfPaginatedItems(feed_and_cat_id){
-  
-  //Writes all the feed deals in string representing a feed and category id to a file. 
-  
-  //prepare to use feed and cat_id by splitting them
-  feed = feed_and_cat_id.split(',')[0]
-  cat_id = feed_and_cat_id.split(',')[1]
-  
-  return new Promise(
-    function (resolve, reject) {
-      walmart.paginateByCategory(parseInt(cat_id), feed, function(response) {
-        var results_array = getRecursiveResponse(response);
-        resolve();
-      });
-    }
-  );
-}
-
 function getPaginatedSpecialFeeds(){
   /*
     Goes through all valid feed/category combinations and returns Promises of getSingleListOfPaginatedItems
   */
   
-  special_feeds_array = [ "specialbuy", "preorder", "clearance" ];
+  let special_feeds_array = [ "specialbuy", "preorder", "clearance" ];
   //get categories available and retrieve deal information for each one
   walmart.taxonomy().then(function(result) {
-    var valid_cat_id_array = [];
+    let valid_cat_id_array = [];
     result.categories.forEach(function(category){
       special_feeds_array.forEach(function(feed){
         /*
           go through each feed and prepare string combination of feed and cat_id
           to retrieve information for.
         */
-          valid_cat_id_array.push(feed+","+category.id); 
+        valid_cat_id_array.push(feed+","+category.id); 
       })
     });
 
-    // map clearance call over valid_cat_id_array
-    var category_special_feeds_array = valid_cat_id_array.map(feed_and_cat_id => () => getSingleListOfPaginatedItems(feed_and_cat_id));
-    debugger;
-    // execute Promises serially
-    paginatedPromiseSerial(category_special_feeds_array)
+    let category_special_feeds_array = [];
+
+    //implement all requests and save them in promises array
+    valid_cat_id_array.forEach(function(feed_and_cat_id, index){
+      category_special_feeds_array.push(walmart.paginateByCategory(parseInt(feed_and_cat_id.split(',')[1]), feed_and_cat_id.split(',')[0], index));
+    });
+    
+    //get pages from fulfilled promises
+    Promise.all(category_special_feeds_array.map(function(promise) {
+      return promise.reflect();
+    })).then(function(inspections) {
+      inspections.forEach(function(inspection, index) {       
+        if (inspection.isFulfilled()) {
+          getRecursiveResponse(inspection.value(), index)                  
+        }
+      })
+    }).catch(console.error.bind(console))
   })
 }
 
-
-
-
-//getSpecialFeedsItems();
-getPaginatedSpecialFeeds();
+getSpecialFeedsItems();
+//getPaginatedSpecialFeeds();

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,17 +1,159 @@
+fs = require('fs');
 if (process.env.NODE_ENV !== 'production') {
   require('dotenv').load();
 }
 
 var walmart = require('../index.js')(process.env.WALMART_API_KEY, {protocol: 'http'});
 
-walmart.stores.search(100, "cheerios").then(function(data) {
-  console.log("Found " + data.count + " items");
-});
+function writeSubCategoryIdsToFile(){
+  /*
+    paths are are separated by "/" between categories. max of 3 categories possible.
+    ids are separated by "_" between categories. max of 3 categories possible.
+    may not need info up to the lowest level but if we do need it for description, this
+    function will generate the classification tree
 
-walmart.getItem(10449075).then(function(item) {
-  console.log(item.product.productName);
-});
+    writes to file in format: upper_category/middle_category/lowest_category,upper-id_middle-id_lowest_id
+  */
+  walmart.taxonomy().then(function(data){
+    data.categories.forEach(function(category){
+      if (category.hasOwnProperty('children')){
+        category.children.forEach(function(child){
+          if (child.hasOwnProperty('children')){
+            child.children.forEach(function(grand_child){
+              var cat_info = grand_child.path + ',' + grand_child.id+'\n';
+              fs.appendFileSync('subcategory_info.txt', cat_info);
+            })
+          }
+          else {
+            var cat_info = child.path + ',' + child.id+'\n';
+            fs.appendFileSync('subcategory_info.txt', cat_info);
+          }
+        })
+      }
+      else {
+        var cat_info = category.name + ' ' + category.id+'\n';
+        fs.appendFileSync('subcategory_info.txt', cat_info);
+      }
+    })
+  });
+}
 
-walmart.getItemByUPC("041100005373").then(function(item) {
-  console.log(item.product.productName);
-});
+
+function writeCategoryIdsToFile(){
+  /*
+    writes category id and names to file
+  */
+  walmart.taxonomy().then(function(data){
+    data.categories.forEach(function(category){
+      var cat_info = category.name + ',' + category.id+'\n';
+
+      fs.appendFileSync('category_info.txt', cat_info);
+    })
+  });
+}
+
+function writeCategoryIdsOnlyToFile(){
+  /*
+    writes category ids that can be used to get clearance information
+    should be called once in a given period since category_ids rarely change daily
+  */
+  walmart.taxonomy().then(function(data){
+    data.categories.forEach(function(category){
+      var cat_info = category.id+'\n';
+      fs.appendFileSync('category_ids.txt', cat_info);
+    })
+  });
+}
+
+function extractProductInfo(product){
+  var twoThreeDayShippingRate = Object.is(product.twoThreeDayShippingRate, undefined) ? '-1.00' : product.twoThreeDayShippingRate; 
+  var msrp = Object.is(product.msrp, undefined) ? '-1.00' : product.msrp;
+  var product_info=product.itemId+','+product.upc+','+product.name+','+product.brandName+','
+    +msrp+','+product.salePrice+','+product.standardShipRate+','
+    +twoThreeDayShippingRate+','+product.availableOnline+','+product.categoryNode
+    +','+product.stock+','+product.freeShippingOver50Dollars+'\n';
+  return product_info;
+}
+
+
+/*
+function that serially calls Promise functions and waits for each of them to be resolved
+Reference: https://hackernoon.com/functional-javascript-resolving-promises-sequentially-7aac18c4431e
+*/
+const promiseSerial = category_clearance_array =>
+category_clearance_array.reduce((promise, func) =>
+promise.then(result => func().then(Array.prototype.concat.bind(result))),
+Promise.resolve([]))
+
+
+function getSpecialFeedsItems(){
+  /*
+    Gets clearance items available in all categories.
+  */
+  
+  /*
+    after testing for a while, found that feed info for some category_ids return server errors
+    So, omitting them from the category_array we are getting feeds info for.
+    Run writeCategoryIdsToFile() if interested in the names of the categories
+  */
+  var invalid_clearance_cat_id_array = ["3920", "976759", "1094765", "6197502", "6197502", "4096", "4104", 
+                                "7796869", "1005862", "5426", "6163033"];
+  var invalid_preorder_cat_id_array = ["1094765", "6197502", "1005862"];
+  var invalid_specialbuy_cat_id_array = ["4104"];
+  //rollback doesn't work at the moment
+  var special_feeds_array = ["clearance", "specialbuy", "bestsellers", "preorder"]; 
+  walmart.taxonomy().then(function(result) { 
+    var valid_cat_id_array = []
+    result.categories.forEach(function(category){
+      special_feeds_array.forEach(function(feed){
+        //if feed is clearance, of the categories returned, use only the valid ones
+        if (feed == "clearance") {
+          if (!(invalid_clearance_cat_id_array.includes(category.id))) {
+            valid_cat_id_array.push(feed+","+category.id);
+          }
+        }
+        else if (feed == "preorder") {
+          //if feed is preorder, of the categories returned, use only the valid ones
+          if (!(invalid_preorder_cat_id_array.includes(category.id))) {
+            valid_cat_id_array.push(feed+","+category.id);
+          }
+        }
+        else if (feed == "specialbuy") {
+          //if feed is specialbuy, of the categories returned, use only the valid ones
+          if (!(invalid_specialbuy_cat_id_array.includes(category.id))) {
+            valid_cat_id_array.push(feed+","+category.id);
+          }
+        }
+        else {
+          valid_cat_id_array.push(feed+","+category.id);
+        }
+      })               
+    })
+
+    // map clearance call over valid_cat_id_array
+    var category_feed_array = valid_cat_id_array.map(feed_and_cat_id => () => walmart.getSpecifiedFeed(feed_and_cat_id));
+    
+    // execute Promises serially
+    promiseSerial(category_feed_array)
+      .then(function(output){
+        //debugger;
+        output.forEach(function(results){
+          if (results.items.length > 0) {
+            results.items.forEach(function(item){
+              /*because we want to compare the features of this item to another marketplace 
+                using some identifier like UPC, it doesn't make sense to retrieve items that don't
+                have a UPC. We can review this decision if we find other identifiers
+              */
+              if (item.hasOwnProperty('upc')){
+                fs.appendFileSync('special_feeds_items.txt', extractProductInfo(item));
+              }
+            })
+          }
+        })
+      })
+      .catch(console.error.bind(console))
+  });
+}
+
+
+getSpecialFeedsItems();

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -15,3 +15,74 @@ walmart.getItem(10449075).then(function(item) {
 walmart.getItemByUPC("041100005373").then(function(item) {
   console.log(item.product.productName);
 });
+
+
+
+
+function writeSubCategoryIdsToFile(){
+  /*
+    paths are are separated by "/" between categories. max of 3 categories possible.
+    ids are separated by "_" between categories. max of 3 categories possible.
+    we may not need info up to the lowest level but if we do need it for description, this
+    function will generate the classification tree
+
+    gets as much info about a category as possible - nests further if walmart provides info
+    can be used to find clearance item by only checking the first id before an underscore
+
+    outputs in the format: upper_category/middle_category/lowest_category,upper-id_middle-id_lowest_id
+  */
+  walmart.taxonomy().then(function(data){
+    for (var i = 0; i < data.categories.length ; i++) {
+      //fs.appendFileSync('subcategory_info.txt', 'data to append');
+      if (data.categories[i].hasOwnProperty('children')){
+        for (var j = 0; j < data.categories[i].children.length ; j++) {
+          //debugger;
+          if (data.categories[i].children[j].hasOwnProperty('children')){
+            for (var k = 0; k < data.categories[i].children[j].children.length; k++) {
+              var cat_info = data.categories[i].children[j].children[k].path + ',' + data.categories[i].children[j].children[k].id+'\n';
+              fs.appendFileSync('subcategory_info.txt', cat_info);
+            }
+          }
+          else {
+            var cat_info = data.categories[i].children[j].path + ',' + data.categories[i].children[j].id+'\n';
+            fs.appendFileSync('subcategory_info.txt', cat_info);
+          }          
+        }
+      }
+      else {
+        var cat_info = data.categories[i].name + ' ' + data.categories[i].id+'\n';
+        fs.appendFileSync('subcategory_info.txt', cat_info);
+      }
+    }
+  });
+}
+
+
+function writeCategoryIdsToFile(){
+  /*
+    this function should be enough for getting all ids that can be used to get clearance information
+  */
+  walmart.taxonomy().then(function(data){
+    for (var i = 0; i < data.categories.length ; i++) {
+      var cat_info = data.categories[i].name + ',' + data.categories[i].id+'\n';
+      fs.appendFileSync('category_info.txt', cat_info);
+    }
+    //console.log("Number of categories is " + data.categories.length)
+  });
+}
+function writeCategoryIdsOnlyToFile(){
+  /*
+    this function should be enough for getting all ids that can be used to get clearance information
+  */
+  walmart.taxonomy().then(function(data){
+    for (var i = 0; i < data.categories.length ; i++) {
+      var cat_info = data.categories[i].id+'\n';
+      //fs.appendFileSync('category_ids.txt', cat_info);
+    }
+    console.log("Number of categories is " + data.categories.length)
+  });
+}
+
+
+
+writeCategoryIdsOnlyToFile();

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -3,7 +3,7 @@ if (process.env.NODE_ENV !== 'production') {
   require('dotenv').load();
 }
 
-var walmart = require('../index.js')(process.env.WALMART_API_KEY, {protocol: 'http'});
+var walmart = require('../index_for_pagination.js')(process.env.WALMART_API_KEY, {protocol: 'http'});
 
 function writeSubCategoryIdsToFile(){
   /*
@@ -46,6 +46,7 @@ function writeCategoryIdsToFile(){
   walmart.taxonomy().then(function(data){
     data.categories.forEach(function(category){
       var cat_info = category.name + ',' + category.id+'\n';
+
       fs.appendFileSync('category_info.txt', cat_info);
     })
   });
@@ -75,12 +76,38 @@ function extractProductInfo(product){
 }
 
 
+function getRecursiveResponse(response){
+  var results_array = [];
+  if (response != undefined && response.hasOwnProperty('items')){
+    response.items.forEach(function(item){
+      // uses upc for identification
+      if (item.hasOwnProperty('upc')){
+        results_array.push(extractProductInfo(item));
+      }
+    })
+    if (response.nextPage) {
+      var new_page_response = walmart.getNewPage(response.nextPage);
+      new_page_response.then(function(resp){
+        results_array = results_array.concat(results_array, getRecursiveResponse(resp));
+      })      
+    }
+    results_array.forEach(function(item){
+      fs.appendFile('special_feeds_items.txt', item, (err) => {
+        if (err) throw err;
+      });
+    })
+    
+    return;
+  }
+}
+
+
 /*
 function that serially calls Promise functions and waits for each of them to be resolved
 Reference: https://hackernoon.com/functional-javascript-resolving-promises-sequentially-7aac18c4431e
 */
-const promiseSerial = category_clearance_array =>
-category_clearance_array.reduce((promise, func) =>
+const promiseSerial = cat_array =>
+cat_array.reduce((promise, func) =>
 promise.then(result => func().then(Array.prototype.concat.bind(result))),
 Promise.resolve([]))
 
@@ -95,30 +122,28 @@ function getSpecialFeedsItems(){
     So, omitting them from the category_array we are getting feeds info for.
     Run writeCategoryIdsToFile() if interested in the names of the categories
   */
+
   var invalid_clearance_cat_id_array = ["3920", "976759", "1094765", "6197502", "6197502", "4096", "4104", 
-                                "7796869", "1005862", "5426", "6163033"];
+                                "7796869", "1005862", "5426", "6163033", "5440", "2636"];
   var invalid_preorder_cat_id_array = ["1094765", "6197502", "1005862"];
-  var invalid_specialbuy_cat_id_array = ["4104"];
-  //rollback doesn't work at the moment
-  var special_feeds_array = ["clearance", "specialbuy", "bestsellers", "preorder"]; 
+  var invalid_specialbuy_cat_id_array = ["4104"];  
+  var special_feeds_array = ["clearance", "specialbuy", "bestsellers", "preorder"];
   walmart.taxonomy().then(function(result) { 
     var valid_cat_id_array = []
     result.categories.forEach(function(category){
       special_feeds_array.forEach(function(feed){
-        //if feed is clearance, of the categories returned, use only the valid ones
+        //return only valid categories for feeds. Valid categories found through testing
         if (feed == "clearance") {
           if (!(invalid_clearance_cat_id_array.includes(category.id))) {
             valid_cat_id_array.push(feed+","+category.id);
           }
         }
         else if (feed == "preorder") {
-          //if feed is preorder, of the categories returned, use only the valid ones
           if (!(invalid_preorder_cat_id_array.includes(category.id))) {
             valid_cat_id_array.push(feed+","+category.id);
           }
         }
         else if (feed == "specialbuy") {
-          //if feed is specialbuy, of the categories returned, use only the valid ones
           if (!(invalid_specialbuy_cat_id_array.includes(category.id))) {
             valid_cat_id_array.push(feed+","+category.id);
           }
@@ -128,31 +153,74 @@ function getSpecialFeedsItems(){
         }
       })               
     })
-
+  
     // map clearance call over valid_cat_id_array
     var category_feed_array = valid_cat_id_array.map(feed_and_cat_id => () => walmart.getSpecifiedFeed(feed_and_cat_id));
     
     // execute Promises serially
     promiseSerial(category_feed_array)
-      .then(function(output){
-        output.forEach(function(results){
-          if (results.items.length > 0) {
-            results.items.forEach(function(item){
-              /*because we want to compare the features of this item to another marketplace 
-                using some identifier like UPC, it doesn't make sense to retrieve items that don't
-                have a UPC. We can review this decision if we find other identifiers
-              */
-              if (item.hasOwnProperty('upc')){
-                fs.appendFileSync('special_feeds_items.txt', extractProductInfo(item));
-              }
-            })
-          }
+      .then(function(results){
+        results.forEach(function(item){
+          //uses upc for identification
+          if (item.hasOwnProperty('upc')){
+            //writing file blocks occasionally, so setting time out to 30 milliseconds for each write
+            setTimeout(function(){ fs.appendFileSync('special_feeds_items.txt', extractProductInfo(item)) }, 30);;
+          }        
         })
       })
       .catch(console.error.bind(console))
   });
 }
 
-getSpecialFeedsItems();
+
+function getSingleListOfPaginatedItems(feed_and_cat_id){
+  
+  //Writes all the feed deals in string representing a feed and category id to a file. 
+  
+  //prepare to use feed and cat_id by splitting them
+  feed = feed_and_cat_id.split(',')[0]
+  cat_id = feed_and_cat_id.split(',')[1]
+  
+  return new Promise(
+    function (resolve, reject) {
+      walmart.paginateByCategory(parseInt(cat_id), feed, function(response) {
+        var results_array = getRecursiveResponse(response);
+        resolve();
+      });
+    }
+  );
+}
 
 
+function getPaginatedSpecialFeeds(){
+  /*
+    Goes through all valid feed/category combinations and returns Promises of getSingleListOfPaginatedItems
+  */
+  
+  special_feeds_array = [ "specialbuy", "preorder", "clearance" ];
+  //get categories available and retrieve deal information for each one
+  walmart.taxonomy().then(function(result) {
+    var valid_cat_id_array = [];
+    result.categories.forEach(function(category){
+      special_feeds_array.forEach(function(feed){
+        /*
+          go through each feed and prepare string combination of feed and cat_id
+          to retrieve information for.
+        */
+          valid_cat_id_array.push(feed+","+category.id); 
+      })
+    });
+
+    // map clearance call over valid_cat_id_array
+    var category_special_feeds_array = valid_cat_id_array.map(feed_and_cat_id => () => getSingleListOfPaginatedItems(feed_and_cat_id));
+    
+    // execute Promises serially
+    promiseSerial(category_special_feeds_array)
+  })
+}
+
+
+
+
+//getSpecialFeedsItems();
+getPaginatedSpecialFeeds();

--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@ var fetch = require('isomorphic-fetch');
 var Promise = require('bluebird');
 
 function _responseToText(response) {
-  if (response.status >= 400) throw new Error("Bad server response");
+  if (response.status >= 400) {
+    throw new Error("Bad server response");
+  }
   return response.text();
 }
 
@@ -39,6 +41,7 @@ module.exports = function(key, options) {
     },
     feeds: {
       items: function(categoryId) {
+        //so far, this requires extra permissions to use.
         return _feed(options, "items", key, categoryId);
       },
       bestSellers: function(categoryId) {
@@ -100,6 +103,13 @@ module.exports = function(key, options) {
         }
         return _get({}, url);
       }
+    }, 
+    getSpecifiedFeed: function(feed_and_cat_id) {
+      //this is easier to loop through for different feeds
+      //feed options include clearance, rollback, specialbuy, preorder, bestsellers
+      feed = feed_and_cat_id.split(',')[0]
+      categoryId = parseInt(feed_and_cat_id.split(',')[1])
+      return _feed(options, feed, key, categoryId);
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -42,8 +42,9 @@ function _paginate(options, category, brand, key, specialOffer, callback) {
     url =  "//api.walmartlabs.com" + options.nextPage;
   }
   return _get(options, url).then(function(response) {
-      callback(response);
-      return response;
+
+    callback(response);
+    return response;
   });
 }
 
@@ -130,14 +131,21 @@ module.exports = function(key, options) {
         return _get({}, url);
       }
     },
-    paginateByCategory: function(categoryId, specialOffer) {
-      return _paginate(options, categoryId, null, key, specialOffer, _callback(arguments));
+    paginateByCategory: function(categoryId, specialOffer, idx) {
+      let delay_coeff = 1001;
+      return Promise.delay(idx*delay_coeff).then(function() {
+        return _paginate(options, categoryId, null, key, specialOffer, _callback(arguments));
+      })      
     },
     paginateByBrand: function(brand, extras, callback) {
       return _paginate(options, null, brand, key, specialOffer, _callback(arguments));
     },
-    getNewPage: function(nextPage) {
-      return _get(options, '//api.walmartlabs.com/'+nextPage);
+    getNewPage: function(nextPage, delay) {
+      let delay_coeff = 1001;
+      //added 2 to delay because there will be a lot of these called
+      return Promise.delay((delay+2)*delay_coeff).then(function() {
+        return _get(options, '//api.walmartlabs.com/'+nextPage);
+      })
     }, 
     getSpecifiedFeed: function(feed_and_cat_id, idx) {
       /*
@@ -146,8 +154,8 @@ module.exports = function(key, options) {
       
         API requires no more than five calls per second. Using delay here to make one call per second
       */
-      var delay_coeff = idx*1001 
-      return Promise.delay(delay_coeff).then(function() {
+      let delay_coeff = 1001; 
+      return Promise.delay(idx*delay_coeff).then(function() {
         return _feed(options, feed_and_cat_id.split(',')[0], key, parseInt(feed_and_cat_id.split(',')[1]));
       })
     }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var Promise = require('bluebird');
 
 function _responseToText(response) {
   if (response.status >= 400) {
-    throw new Error("Bad server response: "+response.status+" - "+response.statusText);
+    throw new Error("Bad server response");
   }
   return response.text();
 }
@@ -139,23 +139,16 @@ module.exports = function(key, options) {
     getNewPage: function(nextPage) {
       return _get(options, '//api.walmartlabs.com/'+nextPage);
     }, 
-    getSpecifiedFeed: function(feed_and_cat_id) {
-      //this is easier to loop through for different feeds
-      //feed options include clearance, rollback, specialbuy, preorder, bestsellers
-      feed = feed_and_cat_id.split(',')[0]
-      categoryId = parseInt(feed_and_cat_id.split(',')[1])
-      var results_array = [];
-      return new Promise(function (resolve, reject) {
-        _feed(options, feed, key, categoryId).then(function(response){
-          if (response.hasOwnProperty('items')) {
-            response.items.forEach(function(item){
-              results_array.push(item);
-            })
-            resolve(results_array);
-          }
-        }).catch(function(err) {
-          reject(err);
-        });        
+    getSpecifiedFeed: function(feed_and_cat_id, idx) {
+      /*
+        Easier to loop through for different feeds - options include clearance, 
+        rollback, specialbuy, preorder, bestsellers
+      
+        API requires no more than five calls per second. Using delay here to make one call per second
+      */
+      var delay_coeff = idx*1001 
+      return Promise.delay(delay_coeff).then(function() {
+        return _feed(options, feed_and_cat_id.split(',')[0], key, parseInt(feed_and_cat_id.split(',')[1]));
       })
     }
   }


### PR DESCRIPTION
This branch gets all the deals from special feeds like clearance, preorder and specialbuy.
It saves all the deals in a file called special_feeds_items.txt. 
Information about which kind of attribute is saved for each item can be found in the extractProductInfo function in simple.js

There is an implementation of paginated deal items too that's commented out getPaginatedSpecialFeeds(); . This implementation reports errors while running and items returned could vary from 500 to like 400k items. I don't think it is where we will find the most important opportunities but I added it since it doesn't hurt to investigate

To test, just run node examples/simple.js as usual - once all items are retrieved, run comment out getSpecialFeedsItems() and uncomment getPaginatedSpecialFeeds(); to see how many items get added from that list too.