### PR TITLE
Exclude all .txt files, analyze by category, add luggage to sales_ranking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,5 @@
 # environment variables
 *.env
 
-# text files
-special_feeds_items.txt
-paginated_special_feeds_items.txt
-subcategory_info.txt
-category_info.txt
-amazon_items.txt
-paired_items.txt
-analyzed_items_info.txt
+# all text files
+*.txt

--- a/src/amazon/AmazonProductList.js
+++ b/src/amazon/AmazonProductList.js
@@ -39,7 +39,7 @@ class AmazonProductList {
             request limit for a given time period has been exceeded. This is a catch to 
             ensure the program still completes with no errors.
           */
-          if (product.Products.Product.AttributeSets) {
+          if (product.Products.Product && product.Products.Product.AttributeSets) {
             amazonProduct = new AmazonProduct(product.Products.Product, product['A$'].Id);
             if (amazonProduct.isProfitable()) {
               products.push(amazonProduct);

--- a/src/amazon/sales_rankings.js
+++ b/src/amazon/sales_rankings.js
@@ -26,6 +26,7 @@ const salesRankings = {
   "Kitchen": 15169390, // Estimated from Home & Kitchen
   "Lawn & Patio": 1189690, // Patio, Lawn & Garden
   "Lighting": 1682760, // Estimated from Tools & Home Improvement
+  "Luggage": 307790, // Estimated from Luggage & Travel Gear
   "Major Appliances": 442230, // Appliances
   "Music": 3514880, // CDs & Vinyl
   "Musical Instruments": 359270, // Musical Instruments

--- a/src/analysis/AnalysisClient.js
+++ b/src/analysis/AnalysisClient.js
@@ -204,10 +204,6 @@ class AnalysisClient {
     
     //write all data into separate file for each category
     this._writeAllCategories(categorizedItems);
-
-
-    //write price analysis info for analyzed products
-    //this._writeToFile("analyzed_items_info.txt");
   }
 }
 

--- a/src/analysis/AnalysisClient.js
+++ b/src/analysis/AnalysisClient.js
@@ -103,7 +103,6 @@ class AnalysisClient {
     let category;
     let categorizedItemsFileName;
     let analysisFolderName = path.join(__dirname, "results", "/");
-    console.log(analysisFolderName)
     if (!fs.existsSync(analysisFolderName)) {
       fs.mkdirSync(analysisFolderName);
     }    
@@ -149,20 +148,15 @@ class AnalysisClient {
     }
     return categoriesRepWeight;
   }
-  /* filters all analyzed products into different categories because
-    it is possible that we will not be able to sell in some categories.
-    Once we know those categories, we won't have to worry about products in there.
-    When we become eligible to sell in those categories, we can look at those items then.
-  */
-  _filterProductsToCategories(analyzedProductsInfo){
-    /*
-    For each item in analyzedProductsInfo
-    If its category is in array, add it to the category
-    else create an array object with key being category and push item to it
-    return categories object
+  
+  _filterProductsToCategories(){
+    /* filters all analyzed products into different categories because
+      it is possible that we will not be able to sell in some categories.
+      Once we know those categories, we won't have to worry about products in there.
+      When we become eligible to sell in those categories, we can look at those items then.
     */
     let categorizedItems = {};
-    analyzedProductsInfo.forEach(function (analyzedProductInfo) {
+    this.analyzedProductsInfo.forEach(function (analyzedProductInfo) {
       if (categorizedItems.hasOwnProperty(analyzedProductInfo.category)) {
         categorizedItems[analyzedProductInfo.category].push(analyzedProductInfo);
       }
@@ -200,7 +194,7 @@ class AnalysisClient {
       } 
     });
 
-    let categorizedItems = this._filterProductsToCategories(that.analyzedProductsInfo);
+    let categorizedItems = this._filterProductsToCategories();
     
     //write all data into separate file for each category
     this._writeAllCategories(categorizedItems);


### PR DESCRIPTION
This PR includes the following changes:
1. Instead of excluding specific .txt files, exclude all of them
2. Print out analyzed items by category. This helps us look specifically in categories we can sell. It also makes it easy to find an item because we know where to look.
3. Found a new category luggage and added it to the sales_ranking.js file
4. Some errors were coming up in AmazonProductList where product.Products.Product was undefined, so added a check for that.