### PR TITLE
Get Lowest Price Offers for items, get real time walmart attributes of items

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -7,32 +7,14 @@ function testAmazonProducts() {
   let analysisClient = new AnalysisClient();
   walmart.client.getSpecialFeedItems()
   .then(function(walmartProducts) {
-    debugger;
-    walmart.client.getProductsByItemId(walmartProducts.products.slice(0,10).map(item => item.itemId)).then(function (upcItems) {
+    /* For each walmart product, retrieve the correlating amazon product.
+    //Walmart UPCs that are associated with zero or more than one Amazon product will be omitted.
+    // Does simple analysis for our desired %ROI threshold and attach Amazon's lowest offer 
+    // information for items that have it. Returns item with no lowest offer info as well
+    */
+    amazonClient.getPairedProducts(walmartProducts.products).then(function(pairedProductsWithOfferInfo) {
       debugger;
-    })
-
-    
-    
-
-
-
-
-
-
-
-
-
-
-    /*// For each walmart product, retrieve the correlating amazon product.
-    // Walmart UPCs that are associated with zero or more than one Amazon product will be omitted.
-    amazonClient.getPairedProducts(walmartProducts.products.slice(0,500))
-    .then(function(pairedProducts) {
-      console.log("Done")
-      //analyze profitability of all items and write relevant info to a file
-      //analysisClient.getSimpleCostAnalysis(pairedProducts);
-      //pairedProducts.writeToFile('paired_items.txt');
-    });*/
+    });
   });
 }
 

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,22 +1,54 @@
 const walmart = require('../src/walmart/index');
 const AmazonClient = require('../src/amazon/AmazonClient');
 const AnalysisClient = require('../src/analysis/AnalysisClient');
+const PairedProductList = require('../src/PairedProductList');
 
 function testAmazonProducts() {
   let amazonClient = new AmazonClient();
   let analysisClient = new AnalysisClient();
-  walmart.client.getSpecialFeedItems()
-  .then(function(walmartProducts) {
-    /* For each walmart product, retrieve the correlating amazon product.
-    //Walmart UPCs that are associated with zero or more than one Amazon product will be omitted.
-    // Does simple analysis for our desired %ROI threshold and attach Amazon's lowest offer 
-    // information for items that have it. Returns item with no lowest offer info as well
-    */
-    amazonClient.getPairedProducts(walmartProducts.products).then(function(pairedProductsWithOfferInfo) {
-      pairedProductsWithOfferInfo.writeToFile('paired_items.txt');
-    });
-  });
+  walmart.client.getSpecialFeedItems().then(function(walmartProducts) {
+    return walmartProducts;
+  }).then(function (walmartProducts) {
+    console.log(`Returned Walmart Products Count After Filtering UPC and Availability: ${walmartProducts.products.length}`)
+    return amazonClient.getPairedProducts(walmartProducts.products);
+  }).then(function (pairedProducts) {
+    console.log(`Returned Amazon ProductsById Count: ${pairedProducts.products.length}`);
+    //simple cost analysis eliminates items with lower than intended %ROI from further AMZN/WLMRT calls
+    let profitablePairedProductsList = analysisClient.getSimpleCostAnalysis(pairedProducts);
+    console.log(`Returned Products Count After Simple Cost Analysis: ${profitablePairedProductsList.products.length}`);
+    //A lot of items have been filtered out, we can get real-time price from WLMRT for remaining
+    let itemsIdList = profitablePairedProductsList.products.map(item => item.walmartProd.itemId);
+    return {
+      idList: itemsIdList,
+      pairedProducts: profitablePairedProductsList
+    };
+  }).then(function (idListAndPairedProdListObj) {
+    return walmart.client.getProductsByItemId(idListAndPairedProdListObj.idList).then(function (realTimeItemsList) {
+      console.log(`Returned Products Count After Walmart Product Lookup: ${realTimeItemsList.products.length}`);
+      //Update pairedProducts to only include items returned from Walmart Product Lookup
+      //It is possible an item that was in PairedProducts before is no longer returned by walmart 
+      //because current availability is not in stock even though special feeds said it was available
+      let realTimePairedProducts = new PairedProductList();
+      realTimeItemsList.products.forEach(function(realTimeWalmartProduct) {
+        realTimePairedProducts.addPairedProduct(idListAndPairedProdListObj.pairedProducts.products.find(item => item.walmartProd.upc == realTimeWalmartProduct.upc).amazonProd, realTimeWalmartProduct);
+      });          
+      //get the lowest offer price for each product from amazon or return current price
+      let itemsASINList = realTimePairedProducts.products.map(item => item.amazonProd.ASIN);
+      return {
+        asinList: itemsASINList,
+        pairedProducts: realTimePairedProducts
+      };
+    })
+  }).then(function (asinListAndPairedProdListObj) {
+    amazonClient.getLowestOfferListingsByASIN(asinListAndPairedProdListObj.pairedProducts, asinListAndPairedProdListObj.asinList).then(function(lowestOfferPairedProducts) {
+      console.log(`Returned Products Count After LowestOfferListings Lookup: ${lowestOfferPairedProducts.products.length}`);
+      lowestOfferPairedProducts.writeToFile('paired_items.txt');
+    })        
+  })
 }
+
+
+
 
 function getRecursiveResponse(response, idx){
   let resultsArray;

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -7,7 +7,24 @@ function testAmazonProducts() {
   let analysisClient = new AnalysisClient();
   walmart.client.getSpecialFeedItems()
   .then(function(walmartProducts) {
-    // For each walmart product, retrieve the correlating amazon product.
+    debugger;
+    walmart.client.getProductsByItemId(walmartProducts.products.slice(0,10).map(item => item.itemId)).then(function (upcItems) {
+      debugger;
+    })
+
+    
+    
+
+
+
+
+
+
+
+
+
+
+    /*// For each walmart product, retrieve the correlating amazon product.
     // Walmart UPCs that are associated with zero or more than one Amazon product will be omitted.
     amazonClient.getPairedProducts(walmartProducts.products.slice(0,500))
     .then(function(pairedProducts) {
@@ -15,7 +32,7 @@ function testAmazonProducts() {
       //analyze profitability of all items and write relevant info to a file
       //analysisClient.getSimpleCostAnalysis(pairedProducts);
       //pairedProducts.writeToFile('paired_items.txt');
-    });
+    });*/
   });
 }
 

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -9,7 +9,7 @@ function testAmazonProducts() {
   .then(function(walmartProducts) {
     // For each walmart product, retrieve the correlating amazon product.
     // Walmart UPCs that are associated with zero or more than one Amazon product will be omitted.
-    amazonClient.getPairedProducts(walmartProducts.products.slice(0,1000))
+    amazonClient.getPairedProducts(walmartProducts.products.slice(0,500))
     .then(function(pairedProducts) {
       console.log("Done")
       //analyze profitability of all items and write relevant info to a file

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -32,15 +32,10 @@ function testAmazonProducts() {
       realTimeItemsList.products.forEach(function(realTimeWalmartProduct) {
         realTimePairedProducts.addPairedProduct(idListAndPairedProdListObj.pairedProducts.products.find(item => item.walmartProd.upc == realTimeWalmartProduct.upc).amazonProd, realTimeWalmartProduct);
       });          
-      //get the lowest offer price for each product from amazon or return current price
-      let itemsASINList = realTimePairedProducts.products.map(item => item.amazonProd.ASIN);
-      return {
-        asinList: itemsASINList,
-        pairedProducts: realTimePairedProducts
-      };
+      return realTimePairedProducts;
     })
-  }).then(function (asinListAndPairedProdListObj) {
-    amazonClient.getLowestOfferListingsByASIN(asinListAndPairedProdListObj.pairedProducts, asinListAndPairedProdListObj.asinList).then(function(lowestOfferPairedProducts) {
+  }).then(function (pairedProducts) {
+    amazonClient.getLowestOfferListingsByASIN(pairedProducts).then(function(lowestOfferPairedProducts) {
       console.log(`Returned Products Count After LowestOfferListings Lookup: ${lowestOfferPairedProducts.products.length}`);
       lowestOfferPairedProducts.writeToFile('paired_items.txt');
     })        

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -13,7 +13,7 @@ function testAmazonProducts() {
     // information for items that have it. Returns item with no lowest offer info as well
     */
     amazonClient.getPairedProducts(walmartProducts.products).then(function(pairedProductsWithOfferInfo) {
-      debugger;
+      pairedProductsWithOfferInfo.writeToFile('paired_items.txt');
     });
   });
 }

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -9,10 +9,11 @@ function testAmazonProducts() {
   .then(function(walmartProducts) {
     // For each walmart product, retrieve the correlating amazon product.
     // Walmart UPCs that are associated with zero or more than one Amazon product will be omitted.
-    amazonClient.getPairedProducts(walmartProducts.products)
+    amazonClient.getPairedProducts(walmartProducts.products.slice(0,1000))
     .then(function(pairedProducts) {
+      console.log("Done")
       //analyze profitability of all items and write relevant info to a file
-      analysisClient.getSimpleCostAnalysis(pairedProducts);
+      //analysisClient.getSimpleCostAnalysis(pairedProducts);
       //pairedProducts.writeToFile('paired_items.txt');
     });
   });

--- a/src/PairedProductList.js
+++ b/src/PairedProductList.js
@@ -20,10 +20,10 @@ class PairedProductList {
   writeToFile(fileName) {
     let textLine;
     let paired_items_file = fs.createWriteStream(fileName);
-
     paired_items_file.on('error', function(err) { console.log(err) });
     this.products.forEach(function(pairedProduct) {
-      textLine = `AMAZON NAME: ${pairedProduct.amazonProd.name}, AMAZON PRICE: ${pairedProduct.amazonProd.price}, ` + 
+      let amazonPrice = (Object.keys(pairedProduct.amazonProd.lowestOfferInfo).length === 0) ? pairedProduct.amazonProd.price : pairedProduct.amazonProd.lowestOfferInfo.lowestOfferInfo.Price.LandedPrice.Amount ;
+      textLine = `AMAZON NAME: ${pairedProduct.amazonProd.name}, AMAZON PRICE: ${amazonPrice}, ` + 
         `WALMART NAME: ${pairedProduct.walmartProd.name}, WALMART PRICE: ${pairedProduct.walmartProd.price}` + "\r\n";
       paired_items_file.write(textLine);
     });

--- a/src/amazon/AmazonClient.js
+++ b/src/amazon/AmazonClient.js
@@ -25,7 +25,7 @@ class AmazonClient {
   /*
     Optional wrapper function around getProductsById. Use this function for returning an array
     of amazon products along with their correlating walmart products.
-    Return: [{amazonProd: AmazonProduct, walmartProd: WalmartProduct}]
+    Return: PairedProducts object
   */
   getPairedProducts(walmartProducts, idType='UPC', delayIndex=0) {
     let pairedProducts = new PairedProductList();
@@ -37,8 +37,8 @@ class AmazonClient {
       return pairedProducts;
     }).catch(function(error) {
       console.log(error);
-      // Something went wrong. Return an empty list.
-      return [];
+      // Something went wrong. Return an empty PairedProductsList object.
+      return new ProductList([]);
     });
   }
 
@@ -119,7 +119,7 @@ class AmazonClient {
     let promises = [];
     let index=0;
     let sliceEnd;
-    let incrementValue=5;
+    const incrementValue=5;
     do {
       sliceEnd = sliceEnd > productIds.length ? productIds.length : index + incrementValue;
       promises.push(this._getProductsById(productIds.slice(index, sliceEnd), idType, index/incrementValue));
@@ -137,12 +137,10 @@ class AmazonClient {
     let promises = [];
     let index=0;
     let sliceEnd;
-    let incrementValue=10;
-    let itemCondition = 'New';
-    let excludeMe = true;
+    const incrementValue=10;
     do {
       sliceEnd = sliceEnd > asinList.length ? asinList.length : index + incrementValue;
-      promises.push(this._getLowestOfferListingsByASIN(asinList.slice(index, sliceEnd), itemCondition, excludeMe, index/incrementValue));
+      promises.push(this._getLowestOfferListingsByASIN(asinList.slice(index, sliceEnd), index/incrementValue));
       index+=incrementValue;
     } while (index < asinList.length);
     return Promise.all(promises.map(function(promise) {
@@ -165,8 +163,10 @@ class AmazonClient {
   /*
     Make a request to Amazon to retrieve the lowest offer listings for 1-10 products by their ASIN.
   */
-  _getLowestOfferListingsByASIN(asinList, itemCondition, excludeMe, delayIndex=0) {
+  _getLowestOfferListingsByASIN(asinList, delayIndex=0) {
     const that = this; 
+    const itemCondition = 'New';
+    const excludeMe = true;
     return Promise.delay(delayIndex*this.delayTime).then(function() {
       return new Promise(function (resolve, reject) {
         that.app.lowestOfferListingsForASIN({asinList: asinList, itemCondition: itemCondition, excludeMe: excludeMe}, function(err, jsonResponse) {

--- a/src/amazon/AmazonClient.js
+++ b/src/amazon/AmazonClient.js
@@ -47,6 +47,7 @@ class AmazonClient {
           matchedPairedProduct.amazonProd.setLowestOfferInformation(lowestOfferInfo);
           secondaryAnalysisList.push(matchedPairedProduct);
         })
+        debugger;
       })
     })
   }

--- a/src/amazon/AmazonClient.js
+++ b/src/amazon/AmazonClient.js
@@ -31,6 +31,8 @@ class AmazonClient {
   */
   getPairedProducts(walmartProducts, idType='UPC', delayIndex=0) {
     let pairedProducts = new PairedProductList();
+    //temporarily using this to return print-friendly object
+    let analyzedPairedProducts = new PairedProductList();
     let that = this;
     return this.getProductsById(walmartProducts.map(item => item.upc), idType, delayIndex)
     .then(function(amazonProducts) {
@@ -43,13 +45,12 @@ class AmazonClient {
       let analyzedItemsList = that.analysisClient.getSimpleCostAnalysis(pairedProducts).map(item => item.ASIN);
       //update analyzedItem wit lowestOfferInfo and return list for further analysis
       return that.getLowestOfferListingsByASIN(analyzedItemsList, delayIndex).then(function(lowestOfferListings) {
-        let secondaryAnalysisList = [];
         lowestOfferListings.forEach(function (lowestOfferInfo) {
           let matchedPairedProduct = pairedProducts.products.find(matchedProduct => matchedProduct.amazonProd.ASIN == lowestOfferInfo.A$.ASIN);
           matchedPairedProduct.amazonProd.setLowestOfferInformation(lowestOfferInfo);
-          secondaryAnalysisList.push(matchedPairedProduct);
+          analyzedPairedProducts.addPairedProduct(matchedPairedProduct.amazonProd, matchedPairedProduct.walmartProd);
         })
-        return secondaryAnalysisList;        
+        return analyzedPairedProducts;        
       })
     }).catch(function(error) {
       console.log(error);

--- a/src/amazon/AmazonClient.js
+++ b/src/amazon/AmazonClient.js
@@ -38,7 +38,7 @@ class AmazonClient {
     }).catch(function(error) {
       console.log(error);
       // Something went wrong. Return an empty PairedProductsList object.
-      return new ProductList([]);
+      return new PairedProductList();
     });
   }
 

--- a/src/amazon/AmazonProduct.js
+++ b/src/amazon/AmazonProduct.js
@@ -21,7 +21,7 @@ class AmazonProduct {
     this.ASIN = product.Identifiers.MarketplaceASIN.ASIN;
     this.bestSalesRanking = this._getBestSalesRanking(product.SalesRankings);
     this.upc = UPC ? UPC : 'UNKNOWN';
-    this.category = product.AttributeSets['ns2:ItemAttributes']['ns2:ProductGroup'],
+    this.category = product.AttributeSets['ns2:ItemAttributes']['ns2:ProductGroup'];
     this.lowestOfferInfo = {};
   }
 

--- a/src/amazon/AmazonProduct.js
+++ b/src/amazon/AmazonProduct.js
@@ -14,7 +14,8 @@ class AmazonProduct {
     this.ASIN = product.Identifiers.MarketplaceASIN.ASIN;
     this.bestSalesRanking = this._getBestSalesRanking(product.SalesRankings);
     this.upc = UPC ? UPC : 'UNKNOWN';
-    this.category = product.AttributeSets['ns2:ItemAttributes']['ns2:ProductGroup'];
+    this.category = product.AttributeSets['ns2:ItemAttributes']['ns2:ProductGroup'],
+    this.lowestOfferInfo = {};
   }
 
   // Returns a string of the basic product information.
@@ -26,6 +27,29 @@ class AmazonProduct {
   /* Profitable products are ones with a good sales ranking and a known sales price and weight. */
   isProfitable() {
     return this._hasKnownPrice() && this._isPopular();
+  }
+
+  // Returns an object containing the product's lowest offer information.
+  setLowestOfferInformation(lowestOfferInfo) {
+    debugger;
+    if (dimensions) {
+      //sometimes, dimensions can be available and some of its attributes would still be unavailable
+      //so, checking each attribute's availability independently
+      return {
+        width: dimensions['ns2:Width'] ? dimensions['ns2:Width'] : 'UNKNOWN',
+        height: dimensions['ns2:Height'] ? dimensions['ns2:Height'] : 'UNKNOWN',
+        length: dimensions['ns2:Length'] ? dimensions['ns2:Length'] : 'UNKNOWN',
+        weight: dimensions['ns2:Weight'] ? dimensions['ns2:Weight'] : 'UNKNOWN',
+        weightComputed: dimensions['ns2:Weight'] ? false : true
+      }
+    } else {
+      return {
+        width: 'UNKNOWN',
+        height: 'UNKNOWN',
+        length: 'UNKNOWN',
+        weight: 'UNKNOWN'
+      }
+    }
   }
 
   // Private methods

--- a/src/amazon/AmazonProduct.js
+++ b/src/amazon/AmazonProduct.js
@@ -1,5 +1,12 @@
 const salesRankings = require('./sales_rankings');
 
+//custom minimum price function
+Array.prototype.hasMin = function(attrib) {
+  return this.reduce(function(prev, curr){ 
+    return parseInt(prev[attrib]['LandedPrice']['Amount']) < parseInt(curr[attrib]['LandedPrice']['Amount']) ? prev : curr; 
+  });
+}
+
 /* Class representing a store item */
 class AmazonProduct {
 
@@ -29,31 +36,18 @@ class AmazonProduct {
     return this._hasKnownPrice() && this._isPopular();
   }
 
-  // Returns an object containing the product's lowest offer information.
+
+  // Sets the lowest offer info property or leaves it as-is.
   setLowestOfferInformation(lowestOfferInfo) {
-    debugger;
-    if (dimensions) {
-      //sometimes, dimensions can be available and some of its attributes would still be unavailable
-      //so, checking each attribute's availability independently
-      return {
-        width: dimensions['ns2:Width'] ? dimensions['ns2:Width'] : 'UNKNOWN',
-        height: dimensions['ns2:Height'] ? dimensions['ns2:Height'] : 'UNKNOWN',
-        length: dimensions['ns2:Length'] ? dimensions['ns2:Length'] : 'UNKNOWN',
-        weight: dimensions['ns2:Weight'] ? dimensions['ns2:Weight'] : 'UNKNOWN',
-        weightComputed: dimensions['ns2:Weight'] ? false : true
-      }
-    } else {
-      return {
-        width: 'UNKNOWN',
-        height: 'UNKNOWN',
-        length: 'UNKNOWN',
-        weight: 'UNKNOWN'
+    if (Array.isArray(lowestOfferInfo.Product.LowestOfferListings.LowestOfferListing)) {
+      this.lowestOfferInfo = { asin: lowestOfferInfo.Product.Identifiers.MarketplaceASIN.ASIN,
+        lowestOfferInfo: lowestOfferInfo.Product.LowestOfferListings.LowestOfferListing.hasMin('Price')
       }
     }
   }
 
   // Private methods
-
+ 
   /* Determine if this amazon product will sell well based on the sales rank. */
   _isPopular() {
     if (this.bestSalesRanking.rank !== 'UNKNOWN') {

--- a/src/analysis/AnalysisClient.js
+++ b/src/analysis/AnalysisClient.js
@@ -77,7 +77,9 @@ class AnalysisClient {
       gCGPercentROI: gCGROIData.gCGPercentROIPerItem,
       upc: pairedProduct.amazonProd.upc,
       category: pairedProduct.amazonProd.category,
-      isWeightComputed: pairedProduct.amazonProd.dimensions.weightComputed
+      isWeightComputed: pairedProduct.amazonProd.dimensions.weightComputed,
+      ASIN: pairedProduct.amazonProd.ASIN,
+      UPC: pairedProduct.amazonProd.upc
     }
     return analyzedProductInfo;
   }
@@ -197,7 +199,9 @@ class AnalysisClient {
     let categorizedItems = this._filterProductsToCategories();
     
     //write all data into separate file for each category
-    this._writeAllCategories(categorizedItems);
+    //this._writeAllCategories(categorizedItems);
+
+    return this.analyzedProductsInfo;
   }
 }
 

--- a/src/analysis/AnalysisClient.js
+++ b/src/analysis/AnalysisClient.js
@@ -196,11 +196,13 @@ class AnalysisClient {
       } 
     });
 
+
+    /* currently not used. Will be used after secondary analysis
     let categorizedItems = this._filterProductsToCategories();
     
     //write all data into separate file for each category
     //this._writeAllCategories(categorizedItems);
-
+    */
     return this.analyzedProductsInfo;
   }
 }

--- a/src/analysis/AnalysisClient.js
+++ b/src/analysis/AnalysisClient.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const PairedProductList = require('./../PairedProductList');
 
 /* Class for handling product profitability analysis */
 class AnalysisClient {
@@ -177,6 +178,7 @@ class AnalysisClient {
     //this helps to compute their shipping price and see what is the profit potential for such items.
     let representativeWeights = that._assignRepresentativeWeightToItem(pairedProductsList);
     let analyzedProduct;
+    let profitablePairedProducts = new PairedProductList();
        
     pairedProductsList.products.forEach(function(pairedProduct){
       //if weight unknown, if we have computed_weight for category, assign it and set_flag 
@@ -192,7 +194,8 @@ class AnalysisClient {
         analyzedProduct = that._getAnalyzedProductInfo(pairedProduct);
       }
       if (analyzedProduct.basePercentROI >= that.ROIThreshold) {
-        that.analyzedProductsInfo.push(analyzedProduct);
+        profitablePairedProducts.addPairedProduct(pairedProduct.amazonProd, pairedProduct.walmartProd);
+        //that.analyzedProductsInfo.push(analyzedProduct); -- not used here might be needed when writing stuff
       } 
     });
 
@@ -203,7 +206,7 @@ class AnalysisClient {
     //write all data into separate file for each category
     //this._writeAllCategories(categorizedItems);
     */
-    return this.analyzedProductsInfo;
+    return profitablePairedProducts;
   }
 }
 

--- a/src/walmart/WalmartClient.js
+++ b/src/walmart/WalmartClient.js
@@ -46,6 +46,10 @@ class WalmartClient {
     }
   }
 
+  getItemByUPC(upcCode) { 
+    return this._get(options, "//www.walmart.com/product/mobile/api/upc/" + upcCode);  
+  }
+
   taxonomy(delayIndex=0) {
     return this._get(`http://api.walmartlabs.com/v1/taxonomy?apiKey=${this.apiKey}`);
   }
@@ -102,7 +106,7 @@ class WalmartClient {
       inspections.forEach(function(inspection, index) {       
         if (inspection.isFulfilled()) {
           if (inspection.value().hasOwnProperty('items')) {
-            console.log(`Promise: ${index} count: ${inspection.value().items.length}`)
+            console.log(`Promise ${index} count: ${inspection.value().items.length}`)
             items.push(...inspection.value().items);
           }                    
         }
@@ -193,6 +197,9 @@ class WalmartClient {
   }
 
   getProductsByItemId(itemIdsList) {
+    /*
+    Get real time walmart item using itemId.
+    */
     let itemsList = [];
     return this._batchedWalmartItemRequest(itemIdsList)
     .then(function(inspections) {
@@ -248,7 +255,9 @@ class WalmartClient {
       return promise.reflect();
     }));
   }
+  
 
+  //Batches ItemId request. Takes up to 20 item Ids at a time
   _batchedWalmartItemRequest(itemIdsList) {
     let promises = [];
     let index = 0;

--- a/src/walmart/WalmartClient.js
+++ b/src/walmart/WalmartClient.js
@@ -113,7 +113,7 @@ class WalmartClient {
       //return a list of itemIds returned from all the special feeds
       return items.map(item => item.itemId);
     }).then(function(itemIdsList) {
-      return that.getProductsByItemId(itemIdsList.slice(0,500)).then(function (realTimeItems) {
+      return that.getProductsByItemId(itemIdsList).then(function (realTimeItems) {
         return new ProductList(realTimeItems);
       })
     }).catch(function(error) {

--- a/src/walmart/WalmartClient.js
+++ b/src/walmart/WalmartClient.js
@@ -262,7 +262,7 @@ class WalmartClient {
     let promises = [];
     let index = 0;
     let sliceEnd;
-    let incrementValue=20;
+    const incrementValue=20;
     do {
       sliceEnd = sliceEnd > itemIdsList.length ? itemIdsList.length : index + incrementValue;
       promises.push(this._getItemByItemId(itemIdsList.slice(index, sliceEnd), index/incrementValue));

--- a/src/walmart/WalmartProductList.js
+++ b/src/walmart/WalmartProductList.js
@@ -6,11 +6,11 @@ class WalmartProductList {
 
   /* productsJSON - json list of walmart products
     Instance attributes:
-      products - list of product objects with UPCs.
-  */
   constructor(productsJSON) {
     this.products = this.productsList(productsJSON);
   }
+      products - list of product objects with UPCs.
+  */
 
   // Create a list of walmart products that all have a UPC code.
   productsList(productsJSON) {

--- a/src/walmart/WalmartProductList.js
+++ b/src/walmart/WalmartProductList.js
@@ -6,18 +6,17 @@ class WalmartProductList {
 
   /* productsJSON - json list of walmart products
     Instance attributes:
+      products - list of product objects with UPCs.
+  */
   constructor(productsJSON) {
     this.products = this.productsList(productsJSON);
   }
-      products - list of product objects with UPCs.
-  */
 
   // Create a list of walmart products that all have a UPC code.
   productsList(productsJSON) {
     let products = [];
-
     productsJSON.forEach(function(product) {
-      if (product.hasOwnProperty('upc') && product.availableOnline) {
+      if (product.hasOwnProperty('upc') && product.availableOnline && product.stock.toLowerCase() === 'available') {
         products.push(new WalmartProduct(product));
       }
     });


### PR DESCRIPTION
Key things:
Now gets lowest priced offers for items we are interested in.
Workflow changed - Before, we would call Walmart special feeds, then call Amazon, then do simple cost analysis. Now, we get Walmart special feeds, match by ProductId on Amazon, do simple cost analysis, get real time item attribute from Walmart, then get lowest priced offer from Amazon. I noticed that each step filters out items as we go through the workflow.
Changed delay time in Amazon calls since the restore rate is per second
Prints item count and promises fulfilled as we go through workflow to understand how items are filtered out.

Next steps: Follow up with secondary analysis using lowest price offer attributes like the lowest price, number of sellers selling at the lowest price, e.t.c.